### PR TITLE
Add VaultScan – privacy-first secrets detection tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Fenrir](https://github.com/Neo23x0/Fenrir) - Simple IOC scanner. It allows scanning any Linux/Unix/OSX system for IOCs in plain bash. Created by the creators of THOR and LOKI.
 * [LOKI](https://github.com/Neo23x0/Loki) - Free IR scanner for scanning endpoint with yara rules and other indicators(IOCs).
 * [Spyre](https://github.com/spyre-project/spyre) - Simple YARA-based IOC scanner written in Go
+* [VaultScan](https://github.com/vaultscan/vaultscan-community) - Privacy-first, offline-first secrets detection tool with GitHub Action support.
 
 ### Timeline Tools
 


### PR DESCRIPTION
Added VaultScan to Scanner Tools. VaultScan is an open-source, offline-first secrets detection tool with GitHub Action support.