### PR TITLE
Add ViperKit to Windows Evidence Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,3 +319,5 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [PowerForensics](https://github.com/Invoke-IR/PowerForensics) - Live disk forensics platform, using PowerShell.
 * [PSRecon](https://github.com/gfoss/PSRecon/) - PSRecon gathers data from a remote Windows host using PowerShell (v2 or later), organizes the data into folders, hashes all extracted data, hashes PowerShell and various system properties, and sends the data off to the security team. The data can be pushed to a share, sent over email, or retained locally.
 * [RegRipper](https://github.com/keydet89/RegRipper3.0) - Open source tool, written in Perl, for extracting/parsing information (keys, values, data) from the Registry and presenting it for analysis.
+* [ViperKit](https://github.com/jtarkington77/ViperKit) - Portable Windows incident response triage toolkit that bundles guided flows for evidence collection, persistence hunting, cleanup, host hardening, and case reporting.
+


### PR DESCRIPTION
Adds ViperKit, a portable Windows IR triage toolkit with guided flows for evidence collection, persistence hunting, cleanup, and case reporting. 