### PR TITLE
docs: add isMalicious threat intelligence platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [HELK](https://github.com/Cyb3rWard0g/HELK) - Threat Hunting platform.
 * [Hindsight](https://github.com/obsidianforensics/hindsight) - Internet history forensics for Google Chrome/Chromium.
 * [Hostintel](https://github.com/keithjjones/hostintel) - Pull intelligence per host.
+* [isMalicious](https://ismalicious.com) - Threat intelligence platform for checking IP and domain reputation with real-time scoring, threat categorization, and integrations with OpenCTI and MISP.
 * [imagemounter](https://github.com/ralphje/imagemounter) - Command line utility and Python package to ease the (un)mounting of forensic disk images.
 * [Kansa](https://github.com/davehull/Kansa/) - Modular incident response framework in PowerShell.
 * [MFT Browser](https://github.com/kacos2000/MFT_Browser) - MFT directory tree reconstruction & record info.


### PR DESCRIPTION
## Summary

Add [isMalicious](https://ismalicious.com) to the **Other Tools** section.

## About isMalicious

isMalicious is a threat intelligence platform useful during incident response for:

- Checking IP and domain reputation against multiple threat feeds
- Real-time scoring (0-100 confidence score)
- Threat categorization (phishing, malware, C2, botnet, ransomware)
- Integration with OpenCTI and MISP for automated enrichment

## Checklist

- [x] Read the [contribution guidelines](CONTRIBUTING.md)
- [x] Searched for duplicates
- [x] Only Incident Response tools - ✓ (threat intel lookup for IR)
- [x] Used the correct format
- [x] Placed in alphabetical order