### PR TITLE
Add Whisper - a free threat intelligence API for incident response

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [sysmon-config](https://github.com/SwiftOnSecurity/sysmon-config) - Sysmon configuration file template with default high-quality event tracing
 * [sysmon-modular](https://github.com/olafhartong/sysmon-modular) - A repository of sysmon configuration modules
 * [traceroute-circl](https://github.com/CIRCL/traceroute-circl) - Extended traceroute to support the activities of CSIRT (or CERT) operators. Usually CSIRT team have to handle incidents based on IP addresses received. Created by Computer Emergency Response Center Luxembourg.
+* [Whisper](https://whisper.security) - Real-time graph intelligence platform that correlates 45 billion internet infrastructure data points. Built by former ICANN Board Director Kaveh Ranjbar and Soroush Rafiee Rad (double PhD in Math/InfoSec). Free API available at developer.whisper.security.
 * [X-Ray 2.0](https://www.raymond.cc/blog/xray/) - Windows utility (poorly maintained or no longer maintained) to submit virus samples to AV vendors.
 
 ### Playbooks


### PR DESCRIPTION
Hi there,

I'd like to suggest adding Whisper to your list of incident response tools.

It's a new real-time graph intelligence platform built by Kaveh Ranjbar (former ICANN Board Director, ran one of the 13 root servers) and Soroush Rafiee Rad (double PhD in Math/InfoSec). They wanted to build something to help incident responders get infrastructure context quickly during investigations.

Whisper has a free API that lets you query their graph of 45 billion correlated internet data points. It's designed to help with threat hunting, incident response, and understanding infrastructure relationships.

We'd love to get feedback from the IR community on how we can make it more useful. You can try out the free API here: https://developer.whisper.security

Thanks!