### PR TITLE
Add n01d-forge to Disk Image Creation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Bitscout](https://github.com/vitaly-kamluk/bitscout) - Bitscout by Vitaly Kamluk helps you build your fully-trusted customizable LiveCD/LiveUSB image to be used for remote digital forensics (or perhaps any other task of your choice). It is meant to be transparent and monitorable by the owner of the system, forensically sound, customizable and compact.
 * [GetData Forensic Imager](http://www.forensicimager.com/) - Windows based program that will acquire, convert, or verify a forensic image in one of the following common forensic file formats.
 * [Guymager](http://guymager.sourceforge.net) - Free forensic imager for media acquisition on Linux.
+* [n01d-forge](https://github.com/bad-antics/n01d-forge) - Native GUI image burner built in Rust with LUKS/VeraCrypt encryption support for creating secure forensic images and bootable drives on Linux.
 * [Magnet ACQUIRE](https://www.magnetforensics.com/magnet-acquire/) - ACQUIRE by Magnet Forensics allows various types of disk acquisitions to be performed on Windows, Linux, and OS X as well as mobile operating systems.
 
 ### Evidence Collection


### PR DESCRIPTION
## Description
Adds [n01d-forge](https://github.com/bad-antics/n01d-forge) to the Disk Image Creation Tools section.

## About n01d-forge
n01d-forge is a native GUI image burner built in Rust for Linux with:
- **LUKS/VeraCrypt encryption** - Create encrypted forensic images
- **Secure imaging** - Built for forensic image creation
- **Bootable drives** - Create bootable media with encryption support
- **Native GUI** - Built with egui for responsive cross-platform interface

## Why Include?
Complements existing tools like Guymager by providing:
- Modern Rust implementation for memory safety
- Built-in encryption support (LUKS/VeraCrypt)
- User-friendly GUI interface
- Open source and actively maintained

GitHub: https://github.com/bad-antics/n01d-forge