### PR TITLE
Add Baudrillard Spectral network forensics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [The Sleuth Kit & Autopsy](http://www.sleuthkit.org) - Unix and Windows based tool which helps in forensic analysis of computers. It comes with various tools which helps in digital forensics. These tools help in analyzing disk images, performing in-depth analysis of file systems, and various other things.
 * [TheHive](https://thehive-project.org/) - Scalable 3-in-1 open source and free solution designed to make life easier for SOCs, CSIRTs, CERTs and any information security practitioner dealing with security incidents that need to be investigated and acted upon swiftly.
 * [Velociraptor](https://github.com/Velocidex/velociraptor) - Endpoint visibility and collection tool
+* [Baudrillard Spectral](https://github.com/bad-antics/baudrillard-suite) - Network forensics tool with spectral decomposition for detecting covert channels, protocol anomalies, and data exfiltration patterns in traffic captures.
 * [X-Ways Forensics](http://www.x-ways.net/forensics/) - Forensics tool for Disk cloning and imaging. It can be used to find deleted files and disk analysis.
 * [Zentral](https://github.com/zentralopensource/zentral) - Combines osquery's powerful endpoint inventory features with a flexible notification and action framework. This enables one to identify and react to changes on OS X and Linux clients.
 


### PR DESCRIPTION
## New Tool Addition

**Tool:** [Baudrillard Spectral](https://github.com/bad-antics/baudrillard-suite)

**Section:** All-In-One Tools

**Description:** Network forensics tool with spectral decomposition for detecting covert channels, protocol anomalies, and data exfiltration patterns in traffic captures.

### Key Features for IR Teams
- Spectral analysis of network traffic for anomaly detection
- Covert channel identification (DNS tunneling, ICMP exfil, steganography)
- Timeline correlation with traffic patterns
- PCAP analysis and visualization
- Entropy-based detection of encrypted exfiltration
- Cross-platform (macOS, Linux, Windows)

Part of the Baudrillard Suite DFIR framework. Happy to adjust placement or formatting!