### PR TITLE
Add ftagent-lite: open-source DDoS PCAP capture tool for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Live Response Collection](https://www.brimorlabs.com/tools/) - Automated tool that collects volatile data from Windows, OSX, and \*nix based operating systems.
 * [Margarita Shotgun](https://github.com/ThreatResponse/margaritashotgun) - Command line utility (that works with or without Amazon EC2 instances) to parallelize remote memory acquisition.
 * [SPECTR3](https://github.com/alpine-sec/SPECTR3) - Acquire, triage and investigate remote evidence via portable iSCSI readonly access
+* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Open-source DDoS traffic monitor for Linux with automatic PCAP capture, 7-day retention, and pre-attack traffic recording for post-incident forensic analysis.
 * [UAC](https://github.com/tclahr/uac) - UAC (Unix-like Artifacts Collector) is a Live Response collection script for Incident Response that makes use of native binaries and tools to automate the collection of AIX, Android, ESXi, FreeBSD, Linux, macOS, NetBSD, NetScaler, OpenBSD and Solaris systems artifacts.
 
 ### Incident Management

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Cold Disk Quick Response](https://github.com/rough007/CDQR) - Streamlined list of parsers to quickly analyze a forensic image file (`dd`, E01, `.vmdk`, etc) and output nine reports.
 * [CyLR](https://github.com/orlikoski/CyLR) - The CyLR tool collects forensic artifacts from hosts with NTFS file systems quickly, securely and minimizes impact to the host.
 * [Forensic Artifacts](https://github.com/ForensicArtifacts/artifacts) - Digital Forensics Artifact Repository
+* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Open-source DDoS traffic monitor for Linux with automatic PCAP capture, 7-day retention, and pre-attack traffic recording for post-incident forensic analysis.
 * [ir-rescue](https://github.com/diogo-fernan/ir-rescue) - Windows Batch script and a Unix Bash script to comprehensively collect host forensic data during incident response.
 * [Live Response Collection](https://www.brimorlabs.com/tools/) - Automated tool that collects volatile data from Windows, OSX, and \*nix based operating systems.
 * [Margarita Shotgun](https://github.com/ThreatResponse/margaritashotgun) - Command line utility (that works with or without Amazon EC2 instances) to parallelize remote memory acquisition.
 * [SPECTR3](https://github.com/alpine-sec/SPECTR3) - Acquire, triage and investigate remote evidence via portable iSCSI readonly access
-* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Open-source DDoS traffic monitor for Linux with automatic PCAP capture, 7-day retention, and pre-attack traffic recording for post-incident forensic analysis.
 * [UAC](https://github.com/tclahr/uac) - UAC (Unix-like Artifacts Collector) is a Live Response collection script for Incident Response that makes use of native binaries and tools to automate the collection of AIX, Android, ESXi, FreeBSD, Linux, macOS, NetBSD, NetScaler, OpenBSD and Solaris systems artifacts.
 
 ### Incident Management


### PR DESCRIPTION
Adds ftagent-lite to the Evidence Collection section.

ftagent-lite captures full PCAP forensics during DDoS incidents with 7-day retention and includes pre-attack traffic, making it useful for post-incident analysis and root cause investigation.

- License: MIT
- Language: Python
- GitHub: https://github.com/Flowtriq/ftagent-lite