### PR TITLE
Add ftagent-lite to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Live Response Collection](https://www.brimorlabs.com/tools/) - Automated tool that collects volatile data from Windows, OSX, and \*nix based operating systems.
 * [Margarita Shotgun](https://github.com/ThreatResponse/margaritashotgun) - Command line utility (that works with or without Amazon EC2 instances) to parallelize remote memory acquisition.
 * [SPECTR3](https://github.com/alpine-sec/SPECTR3) - Acquire, triage and investigate remote evidence via portable iSCSI readonly access
+* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Open-source DDoS traffic monitor for Linux with automatic PCAP capture, 7-day retention, and pre-attack traffic recording for post-incident forensic analysis.
 * [UAC](https://github.com/tclahr/uac) - UAC (Unix-like Artifacts Collector) is a Live Response collection script for Incident Response that makes use of native binaries and tools to automate the collection of AIX, Android, ESXi, FreeBSD, Linux, macOS, NetBSD, NetScaler, OpenBSD and Solaris systems artifacts.
 
 ### Incident Management

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Diffy](https://github.com/Netflix-Skunkworks/diffy) - DFIR tool developed by Netflix's SIRT that allows an investigator to quickly scope a compromise across cloud instances (Linux instances on AWS, currently) during an incident and efficiently triaging those instances for followup actions by showing differences against a baseline.
 * [domfind](https://github.com/diogo-fernan/domfind) - Python DNS crawler for finding identical domain names under different TLDs.
 * [Fileintel](https://github.com/keithjjones/fileintel) - Pull intelligence per file hash.
+* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Lightweight open-source DDoS traffic monitor for Linux. Per-packet inspection detects attack types in real time, with PCAP capture and alerting.
 * [HELK](https://github.com/Cyb3rWard0g/HELK) - Threat Hunting platform.
 * [Hindsight](https://github.com/obsidianforensics/hindsight) - Internet history forensics for Google Chrome/Chromium.
 * [Hostintel](https://github.com/keithjjones/hostintel) - Pull intelligence per host.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Diffy](https://github.com/Netflix-Skunkworks/diffy) - DFIR tool developed by Netflix's SIRT that allows an investigator to quickly scope a compromise across cloud instances (Linux instances on AWS, currently) during an incident and efficiently triaging those instances for followup actions by showing differences against a baseline.
 * [domfind](https://github.com/diogo-fernan/domfind) - Python DNS crawler for finding identical domain names under different TLDs.
 * [Fileintel](https://github.com/keithjjones/fileintel) - Pull intelligence per file hash.
+* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Lightweight network traffic monitor and DDoS attack detector with adaptive baselines, protocol breakdown, and sFlow/NetFlow/IPFIX support.
 * [HELK](https://github.com/Cyb3rWard0g/HELK) - Threat Hunting platform.
 * [Hindsight](https://github.com/obsidianforensics/hindsight) - Internet history forensics for Google Chrome/Chromium.
 * [Hostintel](https://github.com/keithjjones/hostintel) - Pull intelligence per host.

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Cold Disk Quick Response](https://github.com/rough007/CDQR) - Streamlined list of parsers to quickly analyze a forensic image file (`dd`, E01, `.vmdk`, etc) and output nine reports.
 * [CyLR](https://github.com/orlikoski/CyLR) - The CyLR tool collects forensic artifacts from hosts with NTFS file systems quickly, securely and minimizes impact to the host.
 * [Forensic Artifacts](https://github.com/ForensicArtifacts/artifacts) - Digital Forensics Artifact Repository
+* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Open-source DDoS traffic monitor for Linux with automatic PCAP capture, 7-day retention, and pre-attack traffic recording for post-incident forensic analysis.
 * [ir-rescue](https://github.com/diogo-fernan/ir-rescue) - Windows Batch script and a Unix Bash script to comprehensively collect host forensic data during incident response.
 * [Live Response Collection](https://www.brimorlabs.com/tools/) - Automated tool that collects volatile data from Windows, OSX, and \*nix based operating systems.
 * [Margarita Shotgun](https://github.com/ThreatResponse/margaritashotgun) - Command line utility (that works with or without Amazon EC2 instances) to parallelize remote memory acquisition.
 * [SPECTR3](https://github.com/alpine-sec/SPECTR3) - Acquire, triage and investigate remote evidence via portable iSCSI readonly access
-* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Open-source DDoS traffic monitor for Linux with automatic PCAP capture, 7-day retention, and pre-attack traffic recording for post-incident forensic analysis.
 * [UAC](https://github.com/tclahr/uac) - UAC (Unix-like Artifacts Collector) is a Live Response collection script for Incident Response that makes use of native binaries and tools to automate the collection of AIX, Android, ESXi, FreeBSD, Linux, macOS, NetBSD, NetScaler, OpenBSD and Solaris systems artifacts.
 
 ### Incident Management


### PR DESCRIPTION
## Description

Adds [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) to the **Other Tools** section, alphabetically between Fileintel and HELK.

ftagent-lite is an open-source lightweight network traffic monitor and DDoS attack detector with adaptive baselines, protocol breakdown, and sFlow/NetFlow/IPFIX support. It is useful for incident response teams needing network visibility and DDoS detection.

## Checklist

- [x] Entry follows the `* [Name](link) - Description.` format
- [x] Placed in alphabetical order within the section
- [x] Link is to the official GitHub repository