### PR TITLE
Add CyberBriefing threat intelligence API to Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Digital Forensics Artifact Knowledge Base](https://github.com/ForensicArtifacts/artifacts-kb) - Digital Forensics Artifact Knowledge Base
 * [Windows Events Attack Samples](https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES) - Windows Events Attack Samples
 * [Windows Registry Knowledge Base](https://github.com/libyal/winreg-kb) - Windows Registry Knowledge Base
+* [CyberBriefing Threat Intelligence API](https://cyberbriefing.info) - REST API with 2.7M cybersecurity articles (1998-2025), 68K CVEs with exploitation evidence, 63K+ IOCs from 20+ feeds. Useful for IOC enrichment, CVE context, and threat actor profiling during incident response. Free tier available.
 
 ### Linux Distributions
 


### PR DESCRIPTION
## What

Adds [CyberBriefing](https://cyberbriefing.info) to the **Knowledge Bases** section.

## Why

CyberBriefing is a free REST API purpose-built for security investigations and incident response enrichment:

- **2.7M cybersecurity articles** spanning 1998–2025 — historical threat narrative for any CVE or threat actor
- **68K CVEs** enriched with real-world exploitation evidence (which actors used it, in which campaigns)
- **63K+ active IOCs** from 20+ feeds: AlienVault OTX, Abuse.ch URLhaus, ThreatFox (C2/malware), CISA KEV, Tor exit nodes, OpenPhish
- **Free tier**: 100 API calls/day, no credit card required

Use during IR to:
- Correlate observed IOCs against known threat actor infrastructure
- Determine if a CVE in your environment has been actively exploited
- Get historical context on threat actors behind an incident

```bash
# Check if an IP appears in threat intelligence feeds
curl 'https://cyberbriefing.info/api/v1/iocs?q=185.220.101.47&type=ip' \
  -H 'X-API-Key: your-free-key'

# Get exploitation history for a CVE
curl 'https://cyberbriefing.info/api/v1/cves/CVE-2021-44228' \
  -H 'X-API-Key: your-free-key'
```