### PR TITLE
Add gspy to Linux Evidence Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 ### Linux Evidence Collection
 
 * [FastIR Collector Linux](https://github.com/SekoiaLab/Fastir_Collector_Linux) - FastIR for Linux collects different artifacts on live Linux and records the results in CSV files.
+* [gspy](https://github.com/Mutasem-mk4/gspy) - Forensic goroutine-to-syscall inspector for live Go processes using eBPF, reading IDs via process_vm_readv (zero footprint).
 * [MAGNET DumpIt](https://github.com/MagnetForensics/dumpit-linux) - Fast memory acquisition open source tool for Linux written in Rust. Generate full memory crash dumps of Linux machines.
 
 ### Log Analysis Tools


### PR DESCRIPTION
## Description

I am submitting my open source forensic tool to the \Linux Evidence Collection\ category.

[gspy](https://github.com/Mutasem-mk4/gspy) is a forensic goroutine-to-syscall inspector for live Go processes.
It attaches via eBPF uprobes (\untime.execute\) and kernel tracepoints, mapping live Goroutine IDs to system calls by reading process TLS using \process_vm_readv(2)\. This allows for live process introspection without utilizing \ptrace\ or modifying binary structures, making it extremely valuable for incident response and red/blue teaming against Go-based malware/implants.

Thank you for your consideration.