### PR TITLE
Add IPASIS to Other Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [HELK](https://github.com/Cyb3rWard0g/HELK) - Threat Hunting platform.
 * [Hindsight](https://github.com/obsidianforensics/hindsight) - Internet history forensics for Google Chrome/Chromium.
 * [Hostintel](https://github.com/keithjjones/hostintel) - Pull intelligence per host.
+* [IPASIS](https://ipasis.com/) - Real-time IP reputation and email validation API for investigating suspicious interactions. Returns an Interaction Trust Score (0-100) combining VPN/proxy/Tor detection with email risk assessment in a single API call.
 * [imagemounter](https://github.com/ralphje/imagemounter) - Command line utility and Python package to ease the (un)mounting of forensic disk images.
 * [Kansa](https://github.com/davehull/Kansa/) - Modular incident response framework in PowerShell.
 * [MFT Browser](https://github.com/kacos2000/MFT_Browser) - MFT directory tree reconstruction & record info.


### PR DESCRIPTION
Added [IPASIS](https://ipasis.com/) to the Other Tools section.

IPASIS is a real-time IP reputation and email validation API useful for incident response investigations. It combines VPN/proxy/Tor detection with email risk assessment in a single REST API call, returning an Interaction Trust Score (0-100) for each interaction.

Useful for IR teams to quickly assess whether an IP address or email is associated with suspicious activity during incident triage.

- **Website:** https://ipasis.com
- **Documentation:** https://ipasis.com/docs
- **Free tier:** 1,000 requests/day, no credit card required