### PR TITLE
Add Hypoxia to Evidence Collection section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Cold Disk Quick Response](https://github.com/rough007/CDQR) - Streamlined list of parsers to quickly analyze a forensic image file (`dd`, E01, `.vmdk`, etc) and output nine reports.
 * [CyLR](https://github.com/orlikoski/CyLR) - The CyLR tool collects forensic artifacts from hosts with NTFS file systems quickly, securely and minimizes impact to the host.
 * [Forensic Artifacts](https://github.com/ForensicArtifacts/artifacts) - Digital Forensics Artifact Repository
+* [Hypoxia](https://github.com/xinitd/hypoxia) - Cross-platform CLI tool for targeted forensic file collection. Generates SHA-256 manifest, append-only chain-of-custody log, and supports checkpoint/resume for interrupted collections (useful when working with failing media). Pure Python, zero dependencies.
 * [ir-rescue](https://github.com/diogo-fernan/ir-rescue) - Windows Batch script and a Unix Bash script to comprehensively collect host forensic data during incident response.
 * [Live Response Collection](https://www.brimorlabs.com/tools/) - Automated tool that collects volatile data from Windows, OSX, and \*nix based operating systems.
 * [Margarita Shotgun](https://github.com/ThreatResponse/margaritashotgun) - Command line utility (that works with or without Amazon EC2 instances) to parallelize remote memory acquisition.


### PR DESCRIPTION
Adding Hypoxia, an open-source CLI tool for targeted forensic file collection.

Hypoxia fits the Evidence Collection category alongside tools like Acquire, artifactcollector, CyLR, and UAC. It focuses on targeted collection (filter by extension, date range, size) with forensic integrity features.

Key features:
- Pure Python, zero dependencies, runs on Linux/macOS/Windows
- Filters by file extension, date range, and size
- Generates SHA-256 forensic manifest with integrity checksum
- Append-only chain-of-custody log (timestamped, flushed after every write)
- Checkpoint/resume support for interrupted collections (useful when working with failing media - no re-scanning, verified by hash)

Repository: https://github.com/xinitd/hypoxia

Following the contribution guidelines:
- Alphabetized within the Evidence Collection section
- Used the [Name](link) - Description. format
- Added between "Forensic Artifacts" and "ir-rescue"