### PR TITLE
Add Rustinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Logdissect](https://github.com/dogoncouch/logdissect) - CLI utility and Python API for analyzing log files and other data.
 * [NullSec LogReaper](https://github.com/bad-antics/nullsec-logreaper) - High-speed log analysis and forensics tool with multi-format parsing, pattern matching, timeline reconstruction and anomaly detection for incident response.
 * [LogonTracer](https://github.com/JPCERTCC/LogonTracer) - Tool to investigate malicious Windows logon by visualizing and analyzing Windows event log.
+* [Rustinel](https://github.com/Karib0u/rustinel) - Open-source endpoint detection engine that collects ETW/eBPF telemetry and writes ECS NDJSON alerts for detection and investigation pipelines.
 * [Sigma](https://github.com/SigmaHQ/sigma) - Generic signature format for SIEM systems already containing an extensive ruleset.
 * [StreamAlert](https://github.com/airbnb/streamalert) - Serverless, real-time log data analysis framework, capable of ingesting custom data sources and triggering alerts using user-defined logic.
 * [SysmonSearch](https://github.com/JPCERTCC/SysmonSearch) - SysmonSearch makes Windows event log analysis more effective and less time consuming by aggregation of event logs.


### PR DESCRIPTION
Adds Rustinel to the Log Analysis Tools section.

Rustinel is an open-source endpoint detection engine for Windows and Linux that collects ETW/eBPF telemetry, evaluates Sigma/YARA/IOC detections, and writes ECS-compatible NDJSON alerts suitable for investigation pipelines.