### PR TITLE
Add CyStack Stealer Fingerprints to Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 
 ### Knowledge Bases
 
+* [CyStack Stealer Fingerprints](https://github.com/cystack/stealer-fingerprints) - Public catalog of infostealer log fingerprints maintained from CyStack's stealer log intel pipeline and refreshed as new families and variants are observed; covers 30+ families (RedLine, Vidar, Lumma, StealC and others) with banner strings, field signatures, sanitized samples, and YARA rules.
 * [Digital Forensics Artifact Knowledge Base](https://github.com/ForensicArtifacts/artifacts-kb) - Digital Forensics Artifact Knowledge Base
 * [Windows Events Attack Samples](https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES) - Windows Events Attack Samples
 * [Windows Registry Knowledge Base](https://github.com/libyal/winreg-kb) - Windows Registry Knowledge Base


### PR DESCRIPTION
Adds CyStack Stealer Fingerprints to the Knowledge Bases section.

Apache-2.0 catalog of infostealer log fingerprints (banner strings, field signatures, sanitized samples, YARA rules) covering 30+ families including RedLine, Vidar, Lumma, and StealC. Maintained from CyStack's own stealer log intel pipeline and refreshed as new families or variants are observed in production telemetry, not a one-time dump.

Repo: https://github.com/cystack/stealer-fingerprints