### PR TITLE
Add EVTX Inspector to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [SysmonSearch](https://github.com/JPCERTCC/SysmonSearch) - SysmonSearch makes Windows event log analysis more effective and less time consuming by aggregation of event logs.
 * [WELA](https://github.com/Yamato-Security/WELA) - Windows Event Log Analyzer aims to be the Swiss Army knife for Windows event logs.
 * [Zircolite](https://github.com/wagga40/Zircolite) - A standalone and fast SIGMA-based detection tool for EVTX or JSON.
+* [EVTX Inspector](https://github.com/Apurvashelar/EVTX-Inspector) - Browser-based Windows Event Log (.evtx) viewer and CSV analyzer with per-column filtering, row flagging, and multi-file investigation — runs entirely in-browser, zero upload.
 
 ### Memory Analysis Tools
 


### PR DESCRIPTION
Adds EVTX Inspector — a browser-based Windows Event Log analyzer for DFIR.

It fills a specific gap: Eric Zimmerman's Timeline Explorer is Windows-only, and CLI tools like Hayabusa/Chainsaw are headless. Analysts on macOS or Linux currently spin up a Windows VM just to open .evtx files in a usable GUI. EVTX Inspector parses .evtx and CSV exports entirely client-side via WebAssembly, with per-column filters, row flagging, multi-file support, and CSV export.

Live demo: https://evtx-inspector.apurvashelar303.workers.dev/
Repo: https://github.com/Apurvashelar/EVTX-Inspector
License: MIT