### PR TITLE
Add ubuntils to Linux Evidence Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 
 * [FastIR Collector Linux](https://github.com/SekoiaLab/Fastir_Collector_Linux) - FastIR for Linux collects different artifacts on live Linux and records the results in CSV files.
 * [MAGNET DumpIt](https://github.com/MagnetForensics/dumpit-linux) - Fast memory acquisition open source tool for Linux written in Rust. Generate full memory crash dumps of Linux machines.
+* [ubuntils](https://github.com/YOUR-USERNAME/ubuntils) - Python CLI/TUI for forensic triage of Ubuntu systems: detects and remediates persistence mechanisms, collects forensic artifacts, and generates SHA-256-verified timelines with Wazuh integration.
 
 ### Log Analysis Tools
 


### PR DESCRIPTION
Adds ubuntils to the Linux Evidence Collection section.

ubuntils is a Python CLI/TUI for forensic triage of Ubuntu systems. It detects
and remediates 8 classes of persistence mechanisms (cron, systemd, bashrc,
udev, etc.), collects forensic artifacts, and correlates events across
syslog/journald/auditd into a tamper-evident JSON timeline with SHA-256 digest.

- Native Wazuh integration via custom decoders/rules
- Textual TUI with a two-step remediate/confirm flow
- Available on PyPI: https://pypi.org/project/ubuntils/
- Tested on Ubuntu 20.04 / 22.04 / 24.04 (ARM64 + AMD64)