### PR TITLE
Add Malwagon to Sandboxing/Reversing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Digital Forensics and Incident Response (DFIR) teams are groups of people in an 
 * [Hybrid-Analysis](https://www.hybrid-analysis.com/) - Free powerful online sandbox by CrowdStrike.
 * [Intezer](https://analyze.intezer.com/#/) - Intezer Analyze dives into Windows binaries to detect micro-code similarities to known threats, in order to provide accurate yet easy-to-understand results.
 * [Joe Sandbox (Community)](https://www.joesandbox.com/) - Joe Sandbox detects and analyzes potential malicious files and URLs on Windows, Android, Mac OS, Linux, and iOS for suspicious activities; providing comprehensive and detailed analysis reports.
+* [Malwagon](https://malwagon.com) - Online sandbox that detonates files and URLs on instrumented Windows and Linux virtual machines, returning process, registry, file and network behaviour with extracted indicators and ATT&CK technique mappings; a free community tier is available.
 * [Mastiff](https://github.com/KoreLogicSecurity/mastiff) - Static analysis framework that automates the process of extracting key characteristics from a number of different file formats.
 * [Metadefender Cloud](https://www.metadefender.com) - Free threat intelligence platform providing multiscanning, data sanitization and vulnerability assessment of files.
 * [Radare2](https://github.com/radareorg/radare2) - Reverse engineering framework and command-line toolset.


### PR DESCRIPTION
Adds [Malwagon](https://malwagon.com) to the Sandboxing/Reversing Tools section.

It is an online sandbox that detonates a submitted file or URL on instrumented Windows and Linux virtual machines and returns the process tree, registry and file activity, network traffic, extracted indicators and ATT&CK technique mappings. There is a free community tier that needs no payment details, so the entry is usable by readers of this list without a purchase.

Placed in alphabetical order between Joe Sandbox (Community) and Mastiff, using the existing `* [Name](URL) - Description.` format. Single entry, single pull request, per the contribution guidelines. README_ch.md is left untouched so no untranslated text lands in the translation.